### PR TITLE
babel-eslint v7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "homepage": "https://github.com/toppr/eslint-config#readme",
   "peerDependencies": {
-    "babel-eslint": "^6.1.2",
+    "babel-eslint": ">= 6.1.2",
     "eslint": ">= 3",
-    "eslint-plugin-react": "^6.2.2"
+    "eslint-plugin-react": ">= 6.2.2"
   }
 }


### PR DESCRIPTION
Updated peer dependencies for allowing the package to be used along with [babel-eslint](https://github.com/babel/babel-eslint) v7